### PR TITLE
simpler grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ Locus is a *Two-dimensional*, *unbounded*, *sparse*, *efficient*, *grid* spatial
 * Two-Dimensional: The cell grids are squared, and organized in rows and columns.
 * Spatial Hash: Locus can be used to *store* objects on it, potentially moving them around, and then *making queries* related with where those objects are.
 * Unbounded: A locus grid does not need any initial/final dimensions. It grows or shrinks depending on the objects it contains.
-* Sparse: Cells inside the grid are allocated only when they contain an object. Otherwise they are recycled.
-* Efficient: Locus tries very hard to limit the number of table allocations and deallocations it does in order to minimize garbage collection
+* Sparse: Cells inside the grid are allocated only when they contain an object.
+* Efficient: Locus minimizes table allocations and uses efficient bit-shifting operations.
 
-Objects in locus are represented by "axis-aligned bounding boxes", which we will refer to as "boxes". Objects are usually Lua tables representing game objects like enemies, bullets, coins, etc. They can be added, updated, and removed.
+Objects in locus are stored by their position. Objects are usually Lua tables representing game objects like enemies, bullets, coins, etc. They can be added, updated, and removed.
 
-The library uses a grid of squared cells and keeps track of which objects "touch" each cell.
+The library uses a grid of squared cells and keeps track of which objects are in each cell.
 
 This is useful in several scenarios:
 * It can tell "Which objects are in a given rectangular section" quite efficiently
@@ -29,36 +29,31 @@ This is useful in several scenarios:
 local loc=locus([size])
 ```
 Parameters:
-- `size`: An optional parameter that specifies the dimensions (with and height) of the squared cells inside this locus instance. Defaults to `32` when not specified.
+- `size`: An optional parameter that specifies the maximum width or height of the largest object that will be stored in the grid. Defaults to `32` when not specified. Internally, this also determines the cell size.
 
 Return values:
 - `loc`: The newly created locus instance, containing a spatial grid
 
-It is recommended that the grid size is at least as big as one of the "typical" objects in a game, or a multiple of it. For Pico-8 this may be 8,16 or 32.
-
-The ideal situation is that each cell contains 1 (and only 1) game object.
-
-A too small size will make the cells not very efficient, because every object will appear in more than one cell grid.
-
-Making the size too big will have the opposite problem: too many objects on a single grid cell.
+Each object occupies exactly one cell based on its position. The `size` parameter should be set to accommodate your largest object. Query operations automatically search neighboring cells (with a 1-cell border) to detect potential interactions.
 
 You can try experimenting with several sizes in order to arrive to the most optimal one for your game. In general either 16 or 32 should be good defaults.
+
+**Coordinate Limits:** Due to the bit-shifting cell indexing implementation, cell coordinates are limited to PICO-8's 16-bit integer range. This means world coordinates can range from approximately -32768 to 32767 in each dimension (multiplied by your cell size). For typical PICO-8 games this is more than sufficient.
 
 
 ## Adding an object to an existing grid:
 
 ``` lua
-local o=loc.add(obj,x,y,w,h)
+local o=loc.add(obj[,x,y])
 ```
 Parameters:
 - `obj`: the object to be added (usually, a table representing a game object)
-- `x,y`: The `left` and `top` coordinates of the axis-aligned bounding box containing the object
-- `w,h`: The `width` and `height` of the axis-aligned bounding box containing the object
+- `x,y`: The position coordinates of the object (optional if `obj.x` and `obj.y` exist)
 
 Return values:
 - `o`: the object being added (same as `obj`)
 
-Note that objects are *not* represented by "2 corners", but instead by a top-left corner plus width and height.
+Note: If `x` and `y` are not provided, the function will use `obj.x` and `obj.y` instead.
 
 ## Removing an object from locus:
 
@@ -80,12 +75,11 @@ Locus keeps (strong) references to the objects added to it. If you want to remov
 ## Updating an object inside locus:
 
 ``` lua
-local o=loc.update(obj,x,y,w,h)
+local o=loc.update(obj[,x,y])
 ```
 Parameters:
 - `obj`: the object to be updated (usually, represented by a table)
-- `x,y`: The `left` and`top` coordinates of the axis-aligned bounding box containing the object
-- `w,h`: The `width` and `height` of the axis-aligned bounding box containing the object
+- `x,y`: The new position coordinates of the object (optional if `obj.x` and `obj.y` exist)
 
 Return values:
 - `o`: the object being updated (same as `obj`)
@@ -93,22 +87,27 @@ Return values:
 Throws:
 - The error `"unknown object"` if `obj` was not previously added to locus
 
+Note: If `x` and `y` are not provided, the function will use `obj.x` and `obj.y` instead.
+
 ## Querying an area for objects:
 
 ``` lua
-local res=loc.query(x,y,w,h,[filter])
+for obj in loc.query(x,y,w,h) do
+  -- use obj
+end
 ```
 Parameters:
-- `x,y`: The `left` and`top` coordinates of the axis-aligned rectangle being queried
+- `x,y`: The `left` and `top` coordinates of the axis-aligned rectangle being queried
 - `w,h`: The `width` and `height` of the axis-aligned rectangle being queried
-- `filter`: An optional function which can be used to "exclude" or include object from the result. `filter` is a function which takes an object as parameter and returns "truthy" when the object should be included in the result, or "falsy" to not include it. If no filter is specified `locus` will include all objects it encounters on the rectangle
 
 Return values:
-- res: A table of the form `{[obj1]=true, [obj2]=true}` containing all the objects whose boxes intersecting with the specified axis-aligned bounding box.
+- An iterator that yields objects in the queried area
 
 Notes:
-- The table returned is *not ordered* in any way. You might need to sort it out in order for it to make sense in your game.
-- The objects returned are *the objects contained in cells that touch the specified rectangle*. They are *not guaranteed to actually be intersecting with the given rectangle*. You might need an extra check in order to have this guarantee (see example with `rectintersect` in the FAQ section)
+- The iterator returns objects in no particular order.
+- The query automatically includes a 1-cell border in all directions to account for objects in neighboring cells.
+- The objects returned are *the objects contained in cells that touch the specified rectangle* (plus border). They are *not guaranteed to actually be intersecting with the given rectangle*. You might need an extra check in order to have this guarantee (see example with `rectintersect` in the FAQ section).
+- If you need to filter objects, use an `if` statement inside the loop.
 
 
 # Usage
@@ -124,40 +123,36 @@ Save locus to a single file (locus.lua) and then
 ``` lua
 
 -- game objects
-local coin={}
-local enemy={}
-local player={}
+local coin={x=0,y=0}
+local enemy={x=32,y=32}
+local player={x=10,y=10}
 
--- filter function
-function is_enemy(obj)
-  return obj==enemy
-end
-
--- create a grid of 16x16 cells
+-- create a grid with max object size of 16
 local loc=locus(16)
 
--- add objects to the grid
-loc.add(coin, 0,0,8,8)
-loc.add(player, 10,10,8,8)
-loc.add(enemy,32,32,8,8)
+-- add objects to the grid (coordinates can be omitted if obj has x,y properties)
+loc.add(coin)
+loc.add(player)
+loc.add(enemy)
 
 -- move the player
-loc.update(player,20,10,8,8)
+player.x=20
+loc.update(player)
 
 -- delete the coin
 loc.del(coin)
 
--- query all the visible objects
-local visible=loc.query(0,0,128,128)
-
---you can then draw the objects by iterating like so:
-for obj in pairs(visible) do
-  ... call your draw functions like drawplayer(obj)
+-- query and draw all the visible objects
+for obj in loc.query(0,0,128,128) do
+  -- call your draw functions like drawplayer(obj)
 end
 
-
--- query only the visible enemies
-local enemies=loc.query(0,0,128,128,is_enemy)
+-- query only the visible enemies with filtering
+for obj in loc.query(0,0,128,128) do
+  if obj==enemy then
+    -- handle enemy
+  end
+end
 
 ```
 
@@ -166,39 +161,31 @@ See `test_locus.p8` and test_locus.lua for a more complete example about how to 
 
 # Cost
 
-Locus costs 500 tokens approximately.
+Locus costs approximately 320 tokens.
 
-The function has several comments which can be stripped in order to save characters if necessary.
-
-Performance-wise, it does several integer divisions and table manipulations per operation. Locus uses an internal table pool to minimize garbage collection.
+Performance-wise, it uses integer divisions and bit-shifting operations. Query operations use coroutines to provide an iterator interface with minimal memory allocation.
 
 # Preemptive FAQ
 
-## How does hit work?
+## How does it work?
 
-Internally, locus has a sparse list of "rows" (representing the `y` axis). Each row can have one or more cells (on the `x` axis).
+Internally, locus uses a sparse table of cells indexed using bit-shifting operations. Each cell coordinate `(cx, cy)` is encoded as a single number using `cx|(cy>>>16)`, where cx is in the integer part and cy is in the fractional part of PICO-8's 16.16 fixed-point numbers.
 
-locus also "remembers" all of the bounding boxes it has seen in a separate table called `boxes`. `boxes` contains one axis-aligned-bounding-box per object added to locus.
+Locus stores the cell coordinates for each object (not world coordinates), which eliminates redundant conversions during updates and deletions.
 
-Finally, there is also an internal "table pool". When a table is no longer needed(cell depleted of objects, row doesn't have any cells left, box for object which was removed) the tables are added to the pool table instead of being garbage collected. Then the tables can be reused for other purposes, minimizing garbage collection.
-
-While the other methods are "symmetric" with regards to pool usage (`add` takes objects from the pool, `del` adds objects to the pool, `update` adds and removes) the `query` method isn't. It acts as a "pool sink", only taking tables from the pool. This ensures that the pool won't grow too much as long as `query` is used from time to time.
-
-## Why does `query` return a table? Wouldn't it be more efficient to use a callback, or an iterator?
-
-Objects in locus, even small ones, can touch multiple cells as they move. As a result, while querying the cells, we might encounter the same object more than once. The only way to detect this by introducing a `visited` table, which contains the already visited objects. A callback or an iterator would need to be built *on top* of that `visited` table in order to avoid calling the same callback multiple times for the same object. I think this will be undesirable more often than not. So `query` just returns the `visited` table, which is used internally *also* to avoid duplicated objects in the results.
+Query operations use coroutines to provide an iterator interface with minimal memory allocation.
 
 ## When should I *not* use locus?
 
 There's several reasons not to use locus:
 
-* Your game world is fixed in size and densely populated. In this case a non-sparse grid will make more sense; the code will be smaller and faster since it doesn't have to deal with sparse data. Since the world is densely populated, you don't have zones without objects, where locus could save up memory.
-* Your objects can not be represented properly by axis-aligned bounding boxes. Perhaps you have very long, very thin objects that are often "arranged diagonally". This is the worst case scenario for using locus. You might need a different hash map entirely.
-* Your world is already extremely sparse. The main advantage of using locus is that it allows for very fast local queries in an area. If your game has very few interactive objects, it might be simpler to just check all of the objects on every frame. (Take into account that tiles with collision do count as "game objects")
+* Your game world is fixed in size and densely populated. In this case a non-sparse grid will make more sense; the code will be smaller and faster since it doesn't have to deal with sparse data.
+* Your objects are larger than the cell size. Since each object occupies exactly one cell, objects larger than the cell size won't be tracked properly. Set the `size` parameter to accommodate your largest object.
+* Your world is already extremely sparse. The main advantage of using locus is that it allows for very fast local queries in an area. If your game has very few interactive objects, it might be simpler to just check all of the objects on every frame.
 
 ## Can I use locus to accelerate collision detection?
 
-Yes. You can use the `query` object to get a "fast rough list of candidate objects for collision", and then apply a "more expensive collision detection algorithm" (like [hit.p8](https://github.com/kikito/hit.p8/tree/main)) to do use a more costly collision detection algorithm only to the list of candidates.
+Yes. You can use the `query` iterator to get a "fast rough list of candidate objects for collision", and then apply a "more expensive collision detection algorithm" (like [hit.p8](https://github.com/kikito/hit.p8/tree/main)) to use a more costly collision detection algorithm only to the list of candidates.
 
 ## Could you show me how to use it in combination with hit.p8?
 
@@ -209,15 +196,9 @@ Here's a partial example:
 loc = locus()
 ...
 
--- filter for only looking at enemies
-function is_enemy(obj)
-  ...
-end
-
-
 function createbullet(x,y)
   local b={x=x,y=y,w=3,h=3}
-  loc.add(b,b.x,b.y,b.w,b.h)
+  loc.add(b,b.x,b.y)
 end
 
 function updatebullet(b)
@@ -231,14 +212,16 @@ function updatebullet(b)
   -- check the querybox for enemies
   local first_e=nil
   local first_t=32767 --max integer
-  for e in pairs(loc.query(l,t,w,h,is_enemy)) do
-    local t=hit(b.x,b.y,b.w,b.h,
-                e.x,e.y,e.w,e.h,
-                b.x+dx,b.y+dy)
-    -- we could hit several enemies in transit. We only want the first one (minimum t)
-    if t and t<first_t then
-      first_t=t
-      first_e=e
+  for e in loc.query(l,t,w,h) do
+    if is_enemy(e) then
+      local t=hit(b.x,b.y,b.w,b.h,
+                  e.x,e.y,e.w,e.h,
+                  b.x+dx,b.y+dy)
+      -- we could hit several enemies in transit. We only want the first one (minimum t)
+      if t and t<first_t then
+        first_t=t
+        first_e=e
+      end
     end
   end
 
@@ -249,7 +232,7 @@ function updatebullet(b)
   else
     -- no collision. advance bullet
     b.x,b.y=nx,ny
-    loc:update(b,b.x,b.y,b.w,b.h)
+    loc.update(b,b.x,b.y)
   end
 end
 ```
@@ -264,7 +247,7 @@ local loc=locus()
 
 function createplayer(x,y)
   local p={x=x,y=y,w=8,h=16}
-  loc.add(p,p.x,p.y,p.w,p.h)
+  loc.add(p,p.x,p.y)
 end
 
 function rectintersect(x0,y0,w0,h0,x1,y1,w1,h1)
@@ -274,11 +257,11 @@ end
 function updateplayer(p)
   local nx,ny=getnextposition(p)
   p.x,p.y=nx,ny
-  loc.update(p,p.x,p.y,p.w,p.h)
+  loc.update(p,p.x,p.y)
 
-  for c in pairs(loc.query(p.x,p.y,p.w,p.h,is_coin)) do
-    if rectintersect(p.x,p.y,p.w,p.h,
-                     c.x,c.y,c.w,c.h) then
+  for c in loc.query(p.x,p.y,p.w,p.h) do
+    if is_coin(c) and rectintersect(p.x,p.y,p.w,p.h,
+                                     c.x,c.y,c.w,c.h) then
       score+=1
       loc.del(c) -- delete coin. We might need to remove it from other places too
     end
@@ -289,8 +272,8 @@ end
 In this case, we immediately move the player to a new position and then use query on the new player's coordinates to detect coins that might be touching the player.
 
 Notes:
-* With this method, if the player is moving fast enough, they will "tunnel" through coins and other objects. With this method the velocity of the player must be limited, or we must split the movement into smaller step and do a check on every step. The method above (using hit.p8) does not have this problem
-* Notice that eventhough we gave the player's bounding rectangle to `query`, we still need to call `rectintersect` to properly detect that a coin is actually intersecting with the player. This is because `query` will return the *objects that are on the cells that intersect with the given rectangle, but will not guarantee that the objects intersect the rectangle*. For example, on a grid of 32 pixels, the player might be touching 1 grid cell by only 1 pixel on the left, and a coin might be starting on pixel 22 from the left. That coin will still be returned by `query`, eventhough it is not touched by the player.
+* With this method, if the player is moving fast enough, they will "tunnel" through coins and other objects. With this method the velocity of the player must be limited, or we must split the movement into smaller steps and do a check on every step. The method above (using hit.p8) does not have this problem
+* Notice that eventhough we gave the player's bounding rectangle to `query`, we still need to call `rectintersect` to properly detect that a coin is actually intersecting with the player. This is because `query` will return the *objects that are on the cells that intersect with the given rectangle* (plus a 1-cell border), *but will not guarantee that the objects intersect the rectangle*.
 * `query` will return the objects in random order. There's no way to detect which coins get "touched" first. It is not important on this example, but it might be important in more complex games (e.g. if there's an enemy before the coins, then the player might get hurt and not pick up the coins). With hit.p8 you can know which objects go first (smaller `t`).
 
 ## Can I use locus in picotron?
@@ -315,5 +298,38 @@ I am the original author of the [bump.lua](https://github.com/kikito/bump.lua) l
 
 ## Have you used this on an actual videogame?
 
-I am building one, this is but one of the pieces. 
+I am building one, this is but one of the pieces.
+
+# Changelog
+
+## Version 1.0
+
+Major rewrite with breaking API changes:
+
+**Breaking Changes:**
+- `add(obj,x,y,w,h)` → `add(obj,x,y)` - no longer stores object dimensions
+- `update(obj,x,y,w,h)` → `update(obj,x,y)` - no longer stores object dimensions
+- `query(x,y,w,h,filter)` → `query(x,y,w,h)` returns iterator instead of table, removed filter parameter
+- `size` parameter now represents maximum object size instead of just cell size
+- Query automatically includes 1-cell border in all directions
+
+**Improvements:**
+- Reduced token count from ~500 to ~320
+- Eliminated table pool system (simpler code)
+- Uses bit-shifting for efficient cell indexing
+- Iterator-based queries with coroutines (zero table allocations)
+- Stores cell coordinates directly (fewer conversions)
+- Each object occupies exactly one cell
+- Cells use arrays instead of hash tables, allowing safe deletion during query iteration
+- `add()` and `update()` now accept optional coordinates, defaulting to `obj.x` and `obj.y`
+
+**Migration Guide:**
+- Remove `w,h` parameters from `add()` and `update()` calls
+- Change `for obj in pairs(loc.query(...))` to `for obj in loc.query(...)`
+- Move filter logic from query parameter into loop body: `if condition then ... end`
+- Ensure your `size` parameter accommodates your largest object
+
+## Version 0.1
+
+Initial release
 

--- a/locus.lua
+++ b/locus.lua
@@ -1,6 +1,6 @@
 _ENV.locus = function(size)
   size=size or 32
-  local cells,px,py,pool={},{},{},{}
+  local cells,cx,cy,pool={},{},{},{}
 
   local function frompool()
     local tbl=next(pool)
@@ -13,6 +13,25 @@ _ENV.locus = function(size)
 
   local function p2c(x,y)
     return (x\size)+1, (y\size)+1
+  end
+
+  local function addcell(cx,cy,obj)
+    local idx=cx|(cy>>>16)
+    if not cells[idx] then
+      cells[idx]=frompool()
+    end
+    cells[idx][obj]=true
+  end
+
+  local function delcell(cx,cy,obj)
+    local idx=cx|(cy>>>16)
+    local cell=cells[idx]
+    if cell then
+      cell[obj]=nil
+      if not next(cell) then
+        cells[idx],pool[cell]=nil,true
+      end
+    end
   end
 
   local function query_iter(l,t,r,b)
@@ -33,57 +52,31 @@ _ENV.locus = function(size)
     return obj
   end
 
-  local function each(op,p1,l,t,r,b)
-    local cell,idx
-    for cy=t,b do
-      for cx=l,r do
-        idx=cx|(cy>>>16)
-        if op=="add" and not cells[idx] then
-          cells[idx]=frompool()
-        end
-        cell=cells[idx]
-        if cell then
-          if op=="add" then
-            cell[p1]=true
-          elseif op=="del" then
-            cell[p1]=nil
-          elseif op=="free" and not next(cell) then
-            cells[idx],pool[cell]=nil,true
-          end
-        end
-      end
-    end
-  end
-
   return {
-    _px=px,_py=py,_p2c=p2c,_pool=pool,_cells=cells,_size=size,
+    _cx=cx,_cy=cy,_p2c=p2c,_pool=pool,_cells=cells,_size=size,
 
     add=function(obj,x,y)
-      px[obj],py[obj]=x,y
-      local cx,cy=p2c(x,y)
-      each("add",obj,cx,cy,cx,cy)
+      local cellx,celly=p2c(x,y)
+      cx[obj],cy[obj]=cellx,celly
+      addcell(cellx,celly,obj)
       return obj
     end,
 
     del=function(obj)
-      local x,y=assert(px[obj],"unknown object"),py[obj]
-      local cx,cy=p2c(x,y)
-      each("del",obj,cx,cy,cx,cy)
-      each("free",obj,cx,cy,cx,cy)
-      px[obj],py[obj]=nil,nil
+      local cellx,celly=assert(cx[obj],"unknown object"),cy[obj]
+      delcell(cellx,celly,obj)
+      cx[obj],cy[obj]=nil,nil
       return obj
     end,
 
     update=function(obj,x,y)
-      local x0,y0=assert(px[obj],"unknown object"),py[obj]
-      local cx0,cy0=p2c(x0,y0)
+      local cx0,cy0=assert(cx[obj],"unknown object"),cy[obj]
       local cx1,cy1=p2c(x,y)
       if cx0~=cx1 or cy0~=cy1 then
-        each("del",obj,cx0,cy0,cx0,cy0)
-        each("add",obj,cx1,cy1,cx1,cy1)
-        each("free",obj,cx0,cy0,cx0,cy0)
+        delcell(cx0,cy0,obj)
+        addcell(cx1,cy1,obj)
+        cx[obj],cy[obj]=cx1,cy1
       end
-      px[obj],py[obj]=x,y
     end,
 
     query=function(x,y,w,h)

--- a/locus.lua
+++ b/locus.lua
@@ -1,15 +1,6 @@
 _ENV.locus = function(size)
   size=size or 32
-  local cells,cx,cy,pool={},{},{},{}
-
-  local function frompool()
-    local tbl=next(pool)
-    if tbl then
-      pool[tbl]=nil
-      return tbl
-    end
-    return {}
-  end
+  local cells,cx,cy={},{},{}
 
   local function p2c(x,y)
     return (x\size)+1, (y\size)+1
@@ -18,7 +9,7 @@ _ENV.locus = function(size)
   local function addcell(cx,cy,obj)
     local idx=cx|(cy>>>16)
     if not cells[idx] then
-      cells[idx]=frompool()
+      cells[idx]={}
     end
     cells[idx][obj]=true
   end
@@ -29,7 +20,7 @@ _ENV.locus = function(size)
     if cell then
       cell[obj]=nil
       if not next(cell) then
-        cells[idx],pool[cell]=nil,true
+        cells[idx]=nil
       end
     end
   end
@@ -53,7 +44,7 @@ _ENV.locus = function(size)
   end
 
   return {
-    _cx=cx,_cy=cy,_p2c=p2c,_pool=pool,_cells=cells,_size=size,
+    _cx=cx,_cy=cy,_p2c=p2c,_cells=cells,_size=size,
 
     add=function(obj,x,y)
       local cellx,celly=p2c(x,y)

--- a/locus.lua
+++ b/locus.lua
@@ -11,7 +11,7 @@ _ENV.locus = function(size)
     if not cells[idx] then
       cells[idx]={}
     end
-    cells[idx][obj]=true
+    add(cells[idx],obj)
     ocx[obj],ocy[obj]=cx,cy
   end
 
@@ -20,8 +20,8 @@ _ENV.locus = function(size)
     local idx=cx|(cy>>>16)
     local cell=cells[idx]
     if cell then
-      cell[obj]=nil
-      if not next(cell) then
+      del(cell,obj)
+      if #cell==0 then
         cells[idx]=nil
       end
     end
@@ -33,8 +33,8 @@ _ENV.locus = function(size)
       for cx=l,r do
         local cell=cells[cx|(cy>>>16)]
         if cell then
-          for obj in pairs(cell) do
-            yield(obj)
+          for i=#cell,1,-1 do
+            yield(cell[i])
           end
         end
       end

--- a/test_locus.lua
+++ b/test_locus.lua
@@ -74,10 +74,9 @@ function draw_locus(loc)
     end
   end
 
-  -- draw the positions of each object
+  -- count objects in locus
   local objcount=0
-  for obj in pairs(loc._px) do
-    circfill(loc._px[obj],loc._py[obj],1)
+  for _ in pairs(loc._cx) do
     objcount+=1
   end
   -- print how many objects are in locus

--- a/test_locus.lua
+++ b/test_locus.lua
@@ -82,12 +82,6 @@ function draw_locus(loc)
   -- print how many objects are in locus
   circ(7,120,5)
   print(objcount, 5,118)
-
-  -- print the pool size
-  local poolsize=0
-  for _ in pairs(loc._pool) do poolsize+=1 end
-  circ(120,120,5)
-  print(poolsize, 118,118)
 end
 
 function _draw()

--- a/test_locus.lua
+++ b/test_locus.lua
@@ -1,5 +1,6 @@
 local loc
 local vp
+local objs
 
 function rand(low,hi)
   return flr(low+rnd(hi-low))
@@ -13,7 +14,8 @@ function _init()
   loc=locus()
 
   -- add 10 objects to locus
-  for _=1,10 do
+  objs={}
+  for i=1,10 do
     local w=rand(5,15)
     local obj={
       x=rand(30,110),
@@ -24,6 +26,7 @@ function _init()
       r=rnd(),
       col=rand(6,15)
     }
+    objs[i]=obj
     loc.add(obj,obj.x,obj.y)
    end
 end
@@ -76,26 +79,32 @@ function draw_locus(loc)
 
   -- count objects in locus
   local objcount=0
-  for _ in pairs(loc._cx) do
+  for _ in pairs(loc._ocx) do
     objcount+=1
   end
   -- print how many objects are in locus
   circ(7,120,5)
-  print(objcount, 5,118)
+  print(objcount,5,118)
 end
 
 function _draw()
   cls()
-  
+
   color(13)
   -- draw locus in magenta
   draw_locus(loc)
+
+  -- draw all objects as outlines
+  color(6)
+  for obj in all(objs) do
+    rrect(obj.x,obj.y,obj.w,obj.h)
+  end
 
   -- draw the viewport
   color(10)
   rrect(vp.x,vp.y,vp.w,vp.h)
 
-  -- draw he objects that are visible through the viewport with rectfill+color
+  -- draw the objects that are visible through the viewport with rectfill+color
   clip(vp.x,vp.y,vp.w,vp.h)
   for obj in loc.query(vp.x,vp.y,vp.w,vp.h) do
    rrectfill(obj.x,obj.y,obj.w,obj.h,0,obj.col)

--- a/test_locus.lua
+++ b/test_locus.lua
@@ -24,7 +24,7 @@ function _init()
       r=rnd(),
       col=rand(6,15)
     }
-    loc.add(obj,obj.x,obj.y,obj.w,obj.h)
+    loc.add(obj,obj.x,obj.y)
    end
 end
 
@@ -38,7 +38,7 @@ function _update()
   for obj in pairs(loc.query(-128,-128,256,256)) do
     obj.x+= sin(obj.av*t)*obj.r
     obj.y+= cos(obj.av*t)*obj.r
-    loc.update(obj,obj.x,obj.y,obj.w,obj.h)
+    loc.update(obj,obj.x,obj.y)
   end
 
   -- update the viewport
@@ -55,8 +55,10 @@ end
 
 
 function draw_locus(loc)
-  local cl,ct,cr,cb=loc._box2grid(0,0,128,128)
   local size=loc._size
+  -- calculate grid bounds manually
+  local cl,ct=1,1
+  local cr,cb=(128\size)+1,(128\size)+1
   local row,cell
   -- draw the cells
   for cy=ct,cb do
@@ -75,10 +77,10 @@ function draw_locus(loc)
     end
   end
 
-  -- draw the boxes containing each object
+  -- draw the positions of each object
   local objcount=0
-  for _,box in pairs(loc._boxes) do
-    rrect(box[1],box[2],box[3],box[4])
+  for obj in pairs(loc._px) do
+    circfill(loc._px[obj],loc._py[obj],1)
     objcount+=1
   end
   -- print how many objects are in locus

--- a/test_locus.lua
+++ b/test_locus.lua
@@ -59,20 +59,17 @@ function draw_locus(loc)
   -- calculate grid bounds manually
   local cl,ct=1,1
   local cr,cb=(128\size)+1,(128\size)+1
-  local row,cell
+  local cell
   -- draw the cells
   for cy=ct,cb do
-    row=loc._rows[cy]
-    if row then
-      for cx=cl,cr do
-        cell=row[cx]
-        if cell then
-          local x,y=(cx-1)*size,(cy-1)*size
-          rrect(x,y,size,size)
-          local count=0
-          for _ in pairs(cell) do count+=1 end
-          print(count,x+2,y+2)
-        end
+    for cx=cl,cr do
+      cell=loc._cells[cx|(cy>>>16)]
+      if cell then
+        local x,y=(cx-1)*size,(cy-1)*size
+        rrect(x,y,size,size)
+        local count=0
+        for _ in pairs(cell) do count+=1 end
+        print(count,x+2,y+2)
       end
     end
   end

--- a/test_locus.lua
+++ b/test_locus.lua
@@ -35,7 +35,7 @@ function _update()
   -- move all the objects in locus
   -- we use a bigger box than just the screen so that we also update the objects that
   -- are outside of the visible screen
-  for obj in pairs(loc.query(-128,-128,256,256)) do
+  for obj in loc.query(-128,-128,256,256) do
     obj.x+= sin(obj.av*t)*obj.r
     obj.y+= cos(obj.av*t)*obj.r
     loc.update(obj,obj.x,obj.y)
@@ -104,7 +104,7 @@ function _draw()
 
   -- draw he objects that are visible through the viewport with rectfill+color
   clip(vp.x,vp.y,vp.w,vp.h)
-  for obj in pairs(loc.query(vp.x,vp.y,vp.w,vp.h)) do
+  for obj in loc.query(vp.x,vp.y,vp.w,vp.h) do
    rrectfill(obj.x,obj.y,obj.w,obj.h,0,obj.col)
   end
   clip()

--- a/test_locus.p8
+++ b/test_locus.p8
@@ -1,5 +1,5 @@
 pico-8 cartridge // http://www.pico-8.com
-version 42
+version 43
 __lua__
 -- test_locus
 -- by kikito


### PR DESCRIPTION
- **use positions instead of boxes per object**
- **use cells[idx] instead of row[cx][cy]**
- **world:query now returns an iterator. Dropped filter**
- **removed `each`. Not needed since objects now occupy 1 cell all the time**
- **remove the pool**
- **draw outlines of objects in the demo**
- **refactor: rename cx and cy to ocx, ocy. Reorder parameters. Move assert inside delcell**
- **fix issue: deleting elements from cell while iterating didn't guarantee correct order**
- **bump pico-8 version in demo file**
- **update readme for 1.0**
